### PR TITLE
Add Broadcast receiver, split LED-stuff into separate class

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ This project adapts Notification Colors to the led light bar of a WA1053T Androi
 Colors are usually defined [on a NotificationChannel](https://developer.android.com/reference/android/app/NotificationChannel#setLightColor(int)),
 or, on api version < 26 on [the notifications ledARGB property](https://developer.android.com/reference/android/app/Notification#ledARGB).
 
-Note: Flashing the leds is not supported.
+Note: Flashing the LEDs is not supported.
+
+Additionally, using the following generic Broadcast Intents are made available: 
+- `com.robbi5.notificationlightbridge.TURN_OFF`
+- `com.robbi5.notificationlightbridge.SET_COLOR` with an Integer-Extra of `color`
+- `com.robbi5.notificationlightbridge.SET_RAW` with an IntegerList-Extra of `cmd`
+
+The available raw values can be found in the `LED()` companion object.
 
 Installation/Setup
 ------------------

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.MOUNT_UNMOUNT_FILESYSTEMS"
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/robbi5/notificationlightbridge/LED.kt
+++ b/app/src/main/java/com/robbi5/notificationlightbridge/LED.kt
@@ -1,0 +1,107 @@
+package com.robbi5.notificationlightbridge
+
+import android.graphics.Color
+import android.util.Log
+import java.io.DataOutputStream
+
+class LED {
+
+    /*
+     * If a BRIGHTNESS_UP or BRIGHTNESS_DOWN is sent right after a COLOR_ command, the corresponding
+     * color is displayed brighter or dimmer.
+     *
+     * However, if SPEED_UP or SPEED_DOWN is sent right a special mode (CYCLE_RAINBOW, CYCLE_RGB,
+     * BREATH_WHITE or FADE_RAINBOW), the speed of the effect is in- or decreased.
+     *
+     * Since BRIGHTNESS_UP/SPEED_UP and BRIGHTNESS_DOWN/SPEED_DOWN are sharing the same code, an
+     * effect cannot be dimmed. However, since most effects run always at full brightness, this
+     * should be negligible.
+     *
+     * The names of the colors are taken from the documentation of the IR RGB remote control that
+     * inspired the manufacturer to do this craziness this way.
+     *
+     * The comments next to the special modes are the official names of the modes on the IR remote
+     *
+     * Brightness and speed are a set on a 75 step range.
+     */
+    companion object {
+        const val BRIGHTNESS_UP = 0x00; const val SPEED_UP = 0x00
+        const val BRIGHTNESS_DOWN = 0x01; const val SPEED_DOWN = 0x01
+        const val TURN_OFF = 0x02
+        const val TURN_ON = 0x03
+
+        const val COLOR_RED = 0x04
+        const val COLOR_GREEN = 0x05
+        const val COLOR_BLUE = 0x06
+        const val COLOR_WHITE = 0x07
+
+        const val COLOR_ORANGE = 0x08
+        const val COLOR_MINT = 0x09
+        const val COLOR_DARKBLUE = 0x0A
+        const val CYCLE_RAINBOW = 0x0B // "Flash"
+
+        const val COLOR_BROWN = 0x0C
+        const val COLOR_AQUA = 0x0D
+        const val COLOR_PURPLE = 0x0E
+        const val BREATH_WHITE = 0x0F // "Strobe"
+
+        const val COLOR_BEIGE = 0x10
+        const val COLOR_TOPAZ = 0x11
+        const val COLOR_FUCHSIA = 0x12
+        const val FADE_RAINBOW = 0x13
+
+        const val COLOR_YELLOW = 0x14
+        const val COLOR_SKY_BLUE = 0x15
+        const val COLOR_PINK = 0x16
+        const val CYLCE_RGB = 0x17 // "Smooth"
+    }
+
+    fun colorMapping(notificationColor: Int): Int {
+        var hsv: FloatArray = floatArrayOf(0F, 0F, 0F)
+        Color.colorToHSV(notificationColor, hsv)
+
+        if (hsv[1] == 0F && hsv[2] == 100F) return COLOR_WHITE
+        if (hsv[2] == 0F) return TURN_OFF // aka: black
+
+        return when (hsv[0]) {
+            in 0F..30F -> COLOR_RED
+            in 30F..60F -> COLOR_BROWN // orange
+            in 60F..90F -> COLOR_YELLOW
+            in 90F..120F -> COLOR_GREEN
+            in 120F..150F -> COLOR_MINT
+            in 150F..180F -> COLOR_AQUA
+            in 210F..240F -> COLOR_BLUE
+            in 240F..270F -> COLOR_PURPLE
+            in 270F..300F -> COLOR_PINK // magenta
+            in 300F..330F -> COLOR_PINK
+            in 330F..360F -> COLOR_RED
+            else -> 0
+        }
+    }
+
+    fun send(color: Int) {
+        send(listOf(color))
+    }
+
+    fun send(colors: List<Int>) {
+        val colorHexs = colors.map { "%02x".format(it) }
+        Log.i("NLS", "sending ${colorHexs.joinToString()}")
+        val commands = colorHexs.map { "echo w 0x${it} > /sys/devices/platform/led_con_h/zigbee_reset\nsleep 0.1" }
+        rootedExec(commands)
+    }
+
+    fun rootedExec(commands: List<String>) {
+        try {
+            val process = Runtime.getRuntime().exec("su")
+            val os = DataOutputStream(process.outputStream)
+            for (command in commands) {
+                Log.i("NLS", "command ${command}")
+                os.writeBytes(command + "\n")
+            }
+            os.writeBytes("exit\n")
+            os.close()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/app/src/main/java/com/robbi5/notificationlightbridge/NotificationListenerService.kt
+++ b/app/src/main/java/com/robbi5/notificationlightbridge/NotificationListenerService.kt
@@ -3,32 +3,38 @@ package com.robbi5.notificationlightbridge
 import android.annotation.TargetApi
 import android.app.Notification.FLAG_SHOW_LIGHTS
 import android.app.NotificationManager
-import android.graphics.Color
+import android.content.IntentFilter
 import android.os.Build
 import android.service.notification.StatusBarNotification
 import android.util.Log
-import java.io.DataOutputStream
 
 
 class NotificationListenerService: android.service.notification.NotificationListenerService() {
 
-    companion object {
-        const val COLOR_OFF = 0x02
-        const val COLOR_ON = 0x03
-    }
-
     private var notificationManager: NotificationManager? = null
+    private val setColorReceiver = SetColorReceiver()
+    private val led = LED()
 
     override fun onListenerConnected() {
         super.onListenerConnected()
         notificationManager = application.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+        val setColorReceiverIntent = IntentFilter()
+        setColorReceiverIntent.addAction("com.robbi5.notificationlightbridge.TURN_OFF")
+        setColorReceiverIntent.addAction("com.robbi5.notificationlightbridge.SET_COLOR")
+        registerReceiver(setColorReceiver, setColorReceiverIntent)
+    }
+
+    override fun onListenerDisconnected() {
+        super.onListenerDisconnected()
+        unregisterReceiver(setColorReceiver)
     }
 
     override fun onNotificationPosted(sbn: StatusBarNotification?) {
         if (sbn == null || notificationManager == null) return
         val color = pullColor(sbn)
         if (color != 0) {
-            send(listOf(COLOR_ON, color))
+            led.send(listOf(LED.TURN_ON, color))
         }
     }
 
@@ -41,7 +47,7 @@ class NotificationListenerService: android.service.notification.NotificationList
         if (color == null) {
             if (sbn.notification.ledOnMS == 0) return 0
             if (sbn.notification.flags and FLAG_SHOW_LIGHTS == 0) return 0
-            color = colorMapping(sbn.notification.ledARGB)
+            color = led.colorMapping(sbn.notification.ledARGB)
         }
         return color
     }
@@ -60,7 +66,7 @@ class NotificationListenerService: android.service.notification.NotificationList
             return null
         }
 
-        return colorMapping(channel.lightColor)
+        return led.colorMapping(channel.lightColor)
     }
 
     override fun onNotificationRemoved(sbn: StatusBarNotification?) {
@@ -69,61 +75,12 @@ class NotificationListenerService: android.service.notification.NotificationList
         val notifications = activeNotifications.filter { pullColor(it) != 0 }
         if (notifications.isEmpty()) {
             Log.i("NLS", "found no other notifications, turning off")
-            send(COLOR_OFF)
+            led.send(LED.TURN_OFF)
             return
         }
         val n = notifications.maxByOrNull { it.postTime }!!
         val color = pullColor(n)
         Log.i("NLS", "found still active notification, pkg=${n.packageName}, txt=${n.notification.tickerText}")
-        send(color)
-    }
-
-    fun colorMapping(notificationColor: Int): Int {
-        var hsv : FloatArray = floatArrayOf(0F, 0F, 0F)
-        Color.colorToHSV(notificationColor, hsv)
-
-        if (hsv[1] == 0F && hsv[2] == 100F) return 0x07 // white
-        if (hsv[2] == 0F) return 0 // black
-
-        return when(hsv[0]) {
-            in   0F .. 30F  -> 0x04 // red
-            in  30F .. 60F  -> 0x0C // orange
-            in  60F .. 90F  -> 0x14 // yellow
-            in  90F .. 120F -> 0x05 // green
-            in 120F .. 150F -> 0x09
-            in 150F .. 180F -> 0x0D
-            in 210F .. 240F -> 0x06 // blue
-            in 240F .. 270F -> 0x0E
-            in 270F .. 300F -> 0x16 // magenta
-            in 300F .. 330F -> 0x16
-            in 330F .. 360F -> 0x04 // red
-            else -> 0
-        }
-    }
-
-    fun send(color: Int) {
-        send(listOf(color))
-    }
-
-    fun send(colors: List<Int>) {
-        val colorHexs = colors.map { "%02x".format(it) }
-        Log.i("NLS", "sending ${colorHexs.joinToString()}")
-        val commands = colorHexs.map { "echo w 0x${it} > /sys/devices/platform/led_con_h/zigbee_reset\nsleep 0.1" }
-        rootedExec(commands)
-    }
-
-    fun rootedExec(commands: List<String>) {
-        try {
-            val process = Runtime.getRuntime().exec("su")
-            val os = DataOutputStream(process.outputStream)
-            for (command in commands) {
-                Log.i("NLS", "command ${command}")
-                os.writeBytes(command + "\n")
-            }
-            os.writeBytes("exit\n")
-            os.close()
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+        led.send(color)
     }
 }

--- a/app/src/main/java/com/robbi5/notificationlightbridge/NotificationListenerService.kt
+++ b/app/src/main/java/com/robbi5/notificationlightbridge/NotificationListenerService.kt
@@ -13,6 +13,7 @@ class NotificationListenerService: android.service.notification.NotificationList
 
     private var notificationManager: NotificationManager? = null
     private val setColorReceiver = SetColorReceiver()
+    private val pretixReceiver = PretixReceiver()
     private val led = LED()
 
     override fun onListenerConnected() {
@@ -20,14 +21,22 @@ class NotificationListenerService: android.service.notification.NotificationList
         notificationManager = application.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
 
         val setColorReceiverIntent = IntentFilter()
-        setColorReceiverIntent.addAction("com.robbi5.notificationlightbridge.TURN_OFF")
-        setColorReceiverIntent.addAction("com.robbi5.notificationlightbridge.SET_COLOR")
+        SetColorReceiver.intent_actions.map {
+            setColorReceiverIntent.addAction(it)
+        }
         registerReceiver(setColorReceiver, setColorReceiverIntent)
+
+        val pretixReceiverIntent = IntentFilter()
+        PretixReceiver.intent_actions.map {
+            pretixReceiverIntent.addAction(it)
+        }
+        registerReceiver(pretixReceiver, pretixReceiverIntent)
     }
 
     override fun onListenerDisconnected() {
         super.onListenerDisconnected()
         unregisterReceiver(setColorReceiver)
+        unregisterReceiver(pretixReceiver)
     }
 
     override fun onNotificationPosted(sbn: StatusBarNotification?) {

--- a/app/src/main/java/com/robbi5/notificationlightbridge/PretixReceiver.kt
+++ b/app/src/main/java/com/robbi5/notificationlightbridge/PretixReceiver.kt
@@ -1,0 +1,38 @@
+package com.robbi5.notificationlightbridge
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class PretixReceiver : BroadcastReceiver() {
+    companion object {
+        const val INTENT_TURN_OFF = "eu.pretix.led.OFF"
+        const val INTENT_SUCCESS = "eu.pretix.led.SUCCESS"
+        const val INTENT_ERROR = "eu.pretix.led.ERROR"
+        const val INTENT_ATTENTION = "eu.pretix.led.ATTENTION"
+        val intent_actions = listOf(
+            INTENT_TURN_OFF,
+            INTENT_SUCCESS,
+            INTENT_ERROR,
+            INTENT_ATTENTION
+        )
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val led = LED()
+        when (intent.action) {
+            INTENT_TURN_OFF -> {
+                led.send(LED.TURN_OFF)
+            }
+            INTENT_SUCCESS -> {
+                led.send(listOf(LED.TURN_ON, LED.COLOR_GREEN))
+            }
+            INTENT_ERROR -> {
+                led.send(listOf(LED.TURN_ON, LED.COLOR_RED))
+            }
+            INTENT_ATTENTION -> {
+                led.send(listOf(LED.TURN_ON, LED.COLOR_YELLOW))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/robbi5/notificationlightbridge/SetColorReceiver.kt
+++ b/app/src/main/java/com/robbi5/notificationlightbridge/SetColorReceiver.kt
@@ -1,0 +1,26 @@
+package com.robbi5.notificationlightbridge
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class SetColorReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val led = LED()
+        when (intent.action) {
+            "com.robbi5.notificationlightbridge.TURN_OFF" -> {
+                led.send(LED.TURN_OFF)
+            }
+            "com.robbi5.notificationlightbridge.SET_COLOR" -> {
+                if (intent.hasExtra("color")) {
+                    led.send(
+                        listOf(
+                            LED.TURN_ON,
+                            led.colorMapping(intent.getIntExtra("color", LED.TURN_OFF))
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/robbi5/notificationlightbridge/SetColorReceiver.kt
+++ b/app/src/main/java/com/robbi5/notificationlightbridge/SetColorReceiver.kt
@@ -5,19 +5,37 @@ import android.content.Context
 import android.content.Intent
 
 class SetColorReceiver : BroadcastReceiver() {
+    companion object {
+        const val INTENT_TURN_OFF = "com.robbi5.notificationlightbridge.TURN_OFF"
+        const val INTENT_SET_COLOR = "com.robbi5.notificationlightbridge.SET_COLOR"
+        const val INTENT_SET_RAW = "com.robbi5.notificationlightbridge.SET_RAW"
+        val intent_actions = listOf(
+            INTENT_TURN_OFF,
+            INTENT_SET_COLOR,
+            INTENT_SET_RAW
+        )
+    }
+
     override fun onReceive(context: Context, intent: Intent) {
         val led = LED()
         when (intent.action) {
-            "com.robbi5.notificationlightbridge.TURN_OFF" -> {
+            INTENT_TURN_OFF -> {
                 led.send(LED.TURN_OFF)
             }
-            "com.robbi5.notificationlightbridge.SET_COLOR" -> {
+            INTENT_SET_COLOR -> {
                 if (intent.hasExtra("color")) {
                     led.send(
                         listOf(
                             LED.TURN_ON,
                             led.colorMapping(intent.getIntExtra("color", LED.TURN_OFF))
                         )
+                    )
+                }
+            }
+            INTENT_SET_RAW -> {
+                if (intent.hasExtra("cmd")) {
+                    led.send(
+                        intent.getIntArrayExtra("values").toList()
                     )
                 }
             }


### PR DESCRIPTION
Note that we don't actively register the BroadcastReceiver in the manifest.

Since broadcast receivers are apparently only called if the user has at least once opened the application, this won't work. So we are just implicitly registering them when the app is granted access to the notifications.